### PR TITLE
Added missing a library to the requirements list

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -50,9 +50,9 @@ local jekyll site:
 
         $ sudo apt-get install -y ruby rubygems
 
-2. Install jekyll
+2. Install jekyll and rdiscount
 
-        $ sudo gem install jekyll
+        $ sudo gem install rdiscount jekyll
 
 3. Fork this repository and clone your fork locally
 


### PR DESCRIPTION
```
$ jekyll --server
Configuration from /media/TRASH/projects/Altoros/altoros.github.com/_config.yml
Building site: /media/TRASH/projects/Altoros/altoros.github.com -> /media/TRASH/projects/Altoros/altoros.github.com/_site
You are missing a library required for Markdown. Please run:
  $ [sudo] gem install rdiscount

ERROR: YOUR SITE COULD NOT BE BUILT:
------------------------------------
Missing dependency: rdiscount
```
